### PR TITLE
Update lifecycle badge in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![lifecycle](https://img.shields.io/badge/lifecycle-superseded-orange.svg)](https://github.com/NeotomaDB/Workshops)
 # ANSP_Diatoms
 
 ## Use


### PR DESCRIPTION
Changed from "experimental" to "superseded". Replaced tidyverse url to a link to the relevant repo, "Workshops".
